### PR TITLE
Implement "Allowed Mentions"

### DIFF
--- a/runtime-discord/pylon-runtime-discord.d.ts
+++ b/runtime-discord/pylon-runtime-discord.d.ts
@@ -738,6 +738,7 @@ declare module discord {
       content?: string;
       tts?: boolean;
       embed?: Embed | Embed.IEmbed;
+      allowedMentions?: IAllowedMentions;
     }
 
     type OutgoingMessageOptions = IOutgoingMessageOptions &
@@ -745,6 +746,12 @@ declare module discord {
         | { content: string; embed?: Embed | Embed.IEmbed }
         | { content?: string; embed: Embed | Embed.IEmbed }
       );
+
+    interface IAllowedMentions {
+      everyone?: boolean;
+      roles?: true | Array<Snowflake | Role>;
+      users?: true | Array<Snowflake | User | GuildMember>;
+    }
 
     type OutgoingMessage = string | OutgoingMessageOptions | Embed;
   }


### PR DESCRIPTION
Resolves #2 

Add `allowed_mentions` property to createMessage endpoints.

Discord API Docs: https://github.com/discordapp/discord-api-docs/pull/1396

#### Update
This has been merged! Read the second comment for usage and documetnation.

Check out Pylon's type documentation for the new `discord.Message.IAllowedMentions` here:
https://pylon.bot/docs/reference/interfaces/discord.message.iallowedmentions.html

 