### PR TITLE
docs: add usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ These typings are published on npm. To get external intellisense and linting for
 $ npm i --save-dev @pylonbot/runtime @pylonbot/runtime-discord
 ```
 
-This will install the required type definitions. To tell TS that you want to use them, put the following triple-slash comments at the start of your files:
+This will install the required type definitions. To tell TS that you want to use them, put the following triple-slash comments at the start of your `main.ts` file:
 
 ```ts
 /// <reference types="@pylonbot/runtime" />

--- a/README.md
+++ b/README.md
@@ -9,3 +9,18 @@ See our complete type documentation at https://pylon.bot/docs/reference
 See our getting started guides and other examples at https://pylon.bot/docs
 
 Get started today at https://pylon.bot
+
+## Usage
+
+These typings are published on npm. To get external intellisense and linting for Pylon, you're able to install and reference the types. Assuming that you've already run `npm init`, run:
+
+```console
+$ npm i --save-dev @pylonbot/runtime @pylonbot/runtime-discord
+```
+
+This will install the required type definitions. To tell TS that you want to use them, put the following triple-slash comments at the start of your files:
+
+```ts
+/// <reference types="@pylonbot/runtime" />
+/// <reference types="@pylonbot/runtime-discord" />
+```


### PR DESCRIPTION
This PR adds a usage section to the README; it describes how to install and reference the type definitions with npm.